### PR TITLE
Implement fake Terms & Privacy Policy in SignUp and fix logout navigation in App

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -61,7 +61,7 @@ export default function App() {
 
   const navigateTo = (page, entityId = null) => {
     // Handle module switches (auth, events, map, settings)
-    if (['auth', 'events', 'map', 'settings', 'feed'].includes(page)) {
+    if (['auth', 'events', 'map', 'settings', 'feed', 'changePassword', 'privacyPolicy', 'notificationSettings'].includes(page)) {
       setActiveModule(page);
   
       // If navigating to 'auth' without specifying a page, default to 'hellowindow'
@@ -243,7 +243,7 @@ export default function App() {
   if (activeModule === 'settings') {
     return (
       <div className="settings-wrapper">
-        <Settings navigateTo={(page) => setActiveModule(page)} />
+        <Settings navigateTo={navigateTo} />
       </div>
     );
   }

--- a/front-end/src/components/log_in/SignUp.js
+++ b/front-end/src/components/log_in/SignUp.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { faker } from '@faker-js/faker'; 
 import './SignUp.css';
 import googleIcon from '../../assets/log_in/google_icon.png';
 
@@ -7,6 +8,8 @@ export default function SignUp({ setActiveModule, setCurrentPage }) {
   const [password, setPassword] = useState("");
   const [agree, setAgree] = useState(false);
   const [showModal, setShowModal] = useState(false);
+
+  const fakeTerms = faker.lorem.paragraphs(4);
 
   const handleCreateAccount = () => {
     if (!email.trim() || !password.trim()) {
@@ -77,16 +80,11 @@ export default function SignUp({ setActiveModule, setCurrentPage }) {
         Already have an account? Log in here.
       </p>
 
-      {/* Modal */}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <h3>Terms & Privacy Policy</h3>
-            <p>
-              By using this application, you agree to our collection and use of information 
-              in accordance with this policy. This includes how we store, protect, and 
-              utilize your personal data in accordance with industry standards...
-            </p>
+            <p>{fakeTerms}</p> 
             <button className="close-modal" onClick={() => setShowModal(false)}>Close</button>
           </div>
         </div>


### PR DESCRIPTION
- Used `faker.lorem.paragraphs()` to generate mock privacy policy content in SignUp.js modal
- Updated `App.js` navigateTo logic to correctly handle logout back to auth
- Verified that the Settings buttons (Change Password, Privacy Policy, Notification Settings) now all function correctly
- Styling updates applied in Settings.css and PrivacyPolicy.css