### PR TITLE
Fix: resolved feed page UI bugs and improved layout

### DIFF
--- a/front-end/src/components/Feed/FeedCreatePost.js
+++ b/front-end/src/components/Feed/FeedCreatePost.js
@@ -5,7 +5,7 @@ export default function FeedCreatePost({ navigateTo }) {
   const [formData, setFormData] = useState({
     title: '',
     content: '',
-    categories: []
+    category: ''
   });
 
   const categories = ['All','General','Marketplace','Lost and Found','Roommate Request','Safety Alerts'];
@@ -18,12 +18,9 @@ export default function FeedCreatePost({ navigateTo }) {
     navigateTo('main');
   };
 
-  const toggleCategory = (cat) => {
-    if (formData.categories.includes(cat)) {
-      setFormData({ ...formData, categories: formData.categories.filter(c => c !== cat) });
-    } else {
-      setFormData({ ...formData, categories: [...formData.categories, cat] });
-    }
+  const selectCategory = (cat) => {
+    if (cat === 'All') return;
+    setFormData({ ...formData, category: cat });
   };
 
   return (
@@ -62,14 +59,14 @@ export default function FeedCreatePost({ navigateTo }) {
         />
 
         <div className="event-create-categories">
-          <p className="event-create-categories-title">Categories</p>
+          <p className="event-create-categories-title">Category</p>
           <div className="event-create-categories-list">
-            {categories.map(cat => (
+            {categories.filter(c => c !== 'All').map(cat => (
               <button
                 key={cat}
                 type="button"
-                className={formData.categories.includes(cat) ? 'event-create-category-button-active' : 'event-create-category-button'}
-                onClick={() => toggleCategory(cat)}
+                className={formData.category === cat ? 'event-create-category-button-active' : 'event-create-category-button'}
+                onClick={() => selectCategory(cat)}
               >
                 #{cat}
               </button>

--- a/front-end/src/components/Feed/FeedMain.js
+++ b/front-end/src/components/Feed/FeedMain.js
@@ -28,13 +28,13 @@ export default function FeedMain({ navigateTo, isAdmin = false }) {
       post.title.toLowerCase().includes(term) ||
       post.content.toLowerCase().includes(term) ||
       post.author.name.toLowerCase().includes(term);
-    const matchesCategory = selectedCategory === 'All' || post.category.includes(selectedCategory);
+    const matchesCategory = selectedCategory === 'All' || post.category === selectedCategory;
     return matchesSearch && matchesCategory;
   });
 
   const sortedPosts = [...filteredPosts].sort((a, b) => {
-    if (sortBy === 'Latest') return new Date(b.timestamp) - new Date(a.timestamp);
-    if (sortBy === 'Oldest') return new Date(a.timestamp) - new Date(b.timestamp);
+    if (sortBy === 'Latest') return (b.createdAt || 0) - (a.createdAt || 0);
+    if (sortBy === 'Oldest') return (a.createdAt || 0) - (b.createdAt || 0);
     if (sortBy === 'Most Liked') return b.likes - a.likes;
     if (sortBy === 'Most Comments') return b.commentCount - a.commentCount;
     return 0;
@@ -181,9 +181,9 @@ export default function FeedMain({ navigateTo, isAdmin = false }) {
             )}
 
             <div className="feed-post-tags">
-              {post.category.map(cat => (
-                <span key={cat} className="feed-post-tag">#{cat}</span>
-              ))}
+              {post.category && (
+                <span className="feed-post-tag">#{post.category}</span>
+              )}
             </div>
 
             <div className="feed-post-actions">

--- a/front-end/src/components/Feed/FeedSavedPosts.css
+++ b/front-end/src/components/Feed/FeedSavedPosts.css
@@ -1,7 +1,7 @@
 .feed-saved-container { min-height: 100vh; background-color: #f5f5f5; padding-bottom: 20px; }
 .feed-saved-header { background-color: #6B46C1; color: white; padding: 24px 32px; text-align: center; position: relative; }
 .feed-saved-title { margin: 0; font-size: 28px; font-weight: 600; }
-.feed-saved-back-button { position: absolute; left: 32px; top: 50%; transform: translateY(-50%); background: transparent; border: none; color: white; font-size: 18px; cursor: pointer; padding: 8px 16px; line-height: 1; }
+.feed-saved-back-button { position: absolute; left: 32px; top: 50%; transform: translateY(-50%); background: transparent; border: none; color: white; font-size: 18px; cursor: pointer; padding: 8px 16px; line-height: 1; outline: none; }
 .feed-saved-back-button:hover { opacity: 0.8; }
 .feed-saved-back-button:active { opacity: 0.8; }
 .feed-saved-list { display: flex; flex-direction: column; gap: 20px; padding: 24px; }

--- a/front-end/src/components/Feed/FeedSavedPosts.js
+++ b/front-end/src/components/Feed/FeedSavedPosts.js
@@ -1,9 +1,10 @@
 import './FeedSavedPosts.css';
+import { useState, useMemo } from 'react';
 import { mockPosts } from '../../data/Feed/mockFeedData';
 
 export default function FeedSavedPosts({ navigateTo }) {
-  const savedIds = JSON.parse(localStorage.getItem('savedPostIds') || '[]');
-  const savedPosts = mockPosts.filter(p => savedIds.includes(p.id));
+  const [savedIds, setSavedIds] = useState(() => JSON.parse(localStorage.getItem('savedPostIds') || '[]'));
+  const savedPosts = useMemo(() => mockPosts.filter(p => savedIds.includes(p.id)), [savedIds]);
 
   return (
     <div className="feed-saved-container">
@@ -35,10 +36,9 @@ export default function FeedSavedPosts({ navigateTo }) {
               <button className="feed-post-action-button">❤️ {post.likes}</button>
               <button className="feed-post-action-button" onClick={() => {
                 const key = 'savedPostIds';
-                const current = JSON.parse(localStorage.getItem(key) || '[]');
-                const next = current.filter(id => id !== post.id);
+                const next = savedIds.filter(id => id !== post.id);
                 localStorage.setItem(key, JSON.stringify(next));
-                window.location.reload();
+                setSavedIds(next);
               }}>Remove</button>
             </div>
           </div>

--- a/front-end/src/data/Feed/mockFeedData.js
+++ b/front-end/src/data/Feed/mockFeedData.js
@@ -18,25 +18,17 @@ faker.seed(456);
 
 // Generate a random post using faker
 const generateMockPost = (id) => {
-  // Pick random categories (1-2 categories per post)
+  // Pick one random category (single category per post)
   const availableCategories = categories.filter(cat => cat !== 'All');
-  const numCategories = faker.number.int({ min: 1, max: 2 });
-  const postCategories = [];
-  for (let i = 0; i < numCategories; i++) {
-    const remainingCategories = availableCategories.filter(c => !postCategories.includes(c));
-    if (remainingCategories.length > 0) {
-      const category = faker.helpers.arrayElement(remainingCategories);
-      postCategories.push(category);
-    }
-  }
+  const postCategory = faker.helpers.arrayElement(availableCategories);
 
   // Generate post title and content
   const title = faker.lorem.sentence(faker.number.int({ min: 4, max: 8 }));
   const content = faker.lorem.paragraphs(faker.number.int({ min: 1, max: 3 }));
 
   // Generate timestamp (random time in the past 7 days)
-  const timestamp = faker.date.recent({ days: 7 });
-  const formattedTimestamp = formatRelativeTime(timestamp);
+  const createdAt = faker.date.recent({ days: 7 });
+  const formattedTimestamp = formatRelativeTime(createdAt);
 
   // Generate author info
   const authorName = faker.person.fullName();
@@ -49,7 +41,8 @@ const generateMockPost = (id) => {
     title,
     content,
     timestamp: formattedTimestamp,
-    category: postCategories,
+    createdAt: createdAt.getTime(),
+    category: postCategory,
     likes: faker.number.int({ min: 0, max: 150 }),
     commentCount: faker.number.int({ min: 0, max: 50 }),
     image: hasImage ? `https://picsum.photos/seed/post${id}/600/400` : null,


### PR DESCRIPTION
Saved Posts remove redirect fixed: it now updates the list in-place without reloading, so you stay in Feed.
Sorting now uses a raw timestamp (createdAt) in mock data; Latest/Oldest work. This was failing before because we only had formatted strings like “2h ago”.
Saved Posts back button stabilized: uses type="button", outline removed, no transform change on hover/active.
Posts now have a single category:
Mock data generates exactly one category.
Feed filters/render updated for single category.
Create Post switched to single-select; “All” isn’t selectable.