### PR TITLE
User story/70/adding hamburger navbar mobile

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -57,6 +57,108 @@
   padding: 2rem;
 }
 
+/* Mobile Topbar and Drawer - Responsive visibility */
+.mobile-only { 
+  display: none; 
+}
+.desktop-only { 
+  display: flex; 
+}
+
+.mobile-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(15,23,42,0.08);
+}
+
+.hamburger-button {
+  width: 40px;
+  height: 32px;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.hamburger-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #111827;
+  margin: 0 auto;
+}
+.mobile-topbar-title {
+  font-weight: 700;
+  color: #4c1d95;
+  font-size: 18px;
+}
+
+.mobile-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 260px;
+  height: 100vh;
+  background: #fff;
+  box-shadow: 4px 0 16px rgba(0,0,0,0.15);
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  z-index: 1200;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mobile-drawer.open { transform: translateX(0); }
+.mobile-drawer-item {
+  text-align: left;
+  padding: 12px 14px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 8px;
+  color: #4c1d95;
+  font-weight: 600;
+}
+.mobile-drawer-item.active {
+  background: #4c1d95;
+  color: #fff;
+  border-color: #4c1d95;
+}
+.mobile-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.35);
+  z-index: 1150;
+}
+
+/* Default visibility */
+.mobile-only {
+  display: none !important; /* hide on desktop by default */
+}
+.desktop-only {
+  display: flex !important; /* show on desktop by default */
+}
+
+/* Responsive Breakpoints */
+@media (max-width: 768px) {
+  .desktop-only {
+    display: none !important; /* hide navbar on mobile */
+  }
+  .mobile-only {
+    display: flex !important; /* show hamburger & mobile drawer */
+  }
+}
+
+
 /* Events Wrapper - Full Width Responsive */
 .events-wrapper {
   width: 100%;
@@ -84,40 +186,5 @@
   min-height: 60vh;
 }
 
-/* Responsive Breakpoints */
-@media (max-width: 768px) {
-  .tab-bar {
-    padding: 1rem;
-    justify-content: center;
-  }
-
-  .tab-bar-title {
-    display: none;
-  }
-
-  .tab-button {
-    padding: 0.5rem 1.25rem;
-    font-size: 0.9rem;
-  }
-
-  .module-body {
-    padding: 1rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .tab-bar {
-    gap: 0.5rem;
-  }
-
-  .tab-button {
-    padding: 0.5rem 1rem;
-    font-size: 0.85rem;
-  }
-
-  .module-body {
-    padding: 0.75rem;
-  }
-}
 
 

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -51,6 +51,7 @@ export default function App() {
   const [currentPage, setCurrentPage] = useState('hellowindow');
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [selectedPostId, setSelectedPostId] = useState(null);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [previousPage, setPreviousPage] = useState('main'); // Track where user came from
   // TODO Sprint 2: This will be managed by backend session/auth
   // For now, we track RSVP'd events in local state
@@ -342,6 +343,7 @@ export default function App() {
 
   const handleModuleChange = (module) => {
     setActiveModule(module);
+    setIsMobileMenuOpen(false);
 
     if (module === 'events') {
       setCurrentPage('main');
@@ -355,28 +357,84 @@ export default function App() {
 
   return (
     <div className="app-shell">
-      {activeModule !== 'auth' && activeModule !== 'admin' &&(
-        <div className="tab-bar">
-          <div className="tab-bar-title">NextQuad</div>
-          {[
-            { id: 'events', label: 'Events' },
-            { id: 'feed', label: 'Feed' },
-            { id: 'map', label: 'Campus Map' },
-            { id: 'settings', label: 'Settings' }
-          ].map((module) => (
+      {activeModule !== 'auth' && activeModule !== 'admin' && (
+        <>
+          {/* Desktop Tab Bar */}
+          <div className="tab-bar desktop-only">
+            <div className="tab-bar-title">NextQuad</div>
+            {[
+              { id: 'events', label: 'Events' },
+              { id: 'feed', label: 'Feed' },
+              { id: 'map', label: 'Campus Map' },
+              { id: 'settings', label: 'Settings' }
+            ].map((module) => (
+              <button
+                key={module.id}
+                type="button"
+                onClick={() => handleModuleChange(module.id)}
+                aria-pressed={activeModule === module.id}
+                className={`tab-button ${
+                  activeModule === module.id ? 'tab-button-active' : ''
+                }`}
+              >
+                {module.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Mobile Topbar */}
+          <div className="mobile-topbar mobile-only">
             <button
-              key={module.id}
               type="button"
-              onClick={() => handleModuleChange(module.id)}
-              aria-pressed={activeModule === module.id}
-              className={`tab-button ${
-                activeModule === module.id ? 'tab-button-active' : ''
-              }`}
+              className="hamburger-button"
+              aria-label="Open navigation"
+              aria-expanded={isMobileMenuOpen}
+              onClick={() => setIsMobileMenuOpen((v) => !v)}
             >
-              {module.label}
+              <span className="hamburger-bar" />
+              <span className="hamburger-bar" />
+              <span className="hamburger-bar" />
             </button>
-          ))}
-        </div>
+            <div className="mobile-topbar-title">NextQuad</div>
+          </div>
+
+          {/* Mobile Drawer */}
+          <div 
+            className={`mobile-drawer ${isMobileMenuOpen ? 'open' : ''}`}
+            onClick={(e) => {
+              // Close drawer if clicking on drawer background (not on buttons)
+              if (!e.target.classList.contains('mobile-drawer-item')) {
+                setIsMobileMenuOpen(false);
+              }
+            }}
+          >
+            {[
+              { id: 'events', label: 'Events' },
+              { id: 'feed', label: 'Feed' },
+              { id: 'map', label: 'Campus Map' },
+              { id: 'settings', label: 'Settings' }
+            ].map((module) => (
+              <button
+                key={module.id}
+                type="button"
+                className={`mobile-drawer-item ${activeModule === module.id ? 'active' : ''}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleModuleChange(module.id);
+                }}
+              >
+                {module.label}
+              </button>
+            ))}
+          </div>
+          {isMobileMenuOpen && (
+            <div
+              className="mobile-drawer-overlay mobile-only"
+              onClick={() => setIsMobileMenuOpen(false)}
+              aria-hidden
+            />
+          )}
+        </>
       )}
       <div className="module-body">{renderActiveModule()}</div>
     </div>


### PR DESCRIPTION
Added a responsive mobile navbar:
Desktop keeps existing tab bar.
Mobile shows a top-left hamburger that opens a slide-in drawer with Events, Feed, Campus Map, Settings.
Drawer overlay closes on tap; selecting an item navigates and closes the drawer.
Spacing/back-button: mobile topbar is separate from page headers and content; module body has top padding on mobile to avoid overlap. Back buttons remain in page headers and won’t conflict with the hamburger.