### PR TITLE
Adding 'resolved' tag to posts in a query category

### DIFF
--- a/back-end/controllers/feed/postsController.js
+++ b/back-end/controllers/feed/postsController.js
@@ -148,7 +148,9 @@ const createPost = (req, res) => {
         userId: 'user123' // TODO: Get from auth
       },
       isLikedByUser: false,
-      updatedAt: new Date()
+      updatedAt: new Date(),
+      resolved: false,
+      editCount: 0
     };
 
     mockPosts.push(newPost);
@@ -195,6 +197,8 @@ const updatePost = (req, res) => {
 
     // Update fields
     const { title, content, category, image, resolved } = req.body;
+    console.log('Update request body:', req.body);
+    console.log('Resolved value received:', resolved, 'Type:', typeof resolved);
     let edited = false;
     if (title && title !== post.title) { post.title = title; edited = true; }
     if (content && content !== post.content) { post.content = content; edited = true; }
@@ -207,6 +211,7 @@ const updatePost = (req, res) => {
     }
 
     mockPosts[postIndex] = post;
+    console.log('Updated post resolved status:', post.resolved);
 
     res.status(200).json({
       success: true,

--- a/front-end/src/components/Feed/FeedMain.js
+++ b/front-end/src/components/Feed/FeedMain.js
@@ -86,6 +86,20 @@ export default function FeedMain({ navigateTo, isAdmin = false }) {
     }
   };
 
+  // Expose function to update a post from external components (like MyPosts)
+  useEffect(() => {
+    window.updateFeedMainPost = (updatedPost) => {
+      setPosts(prevPosts => 
+        prevPosts.map(post => 
+          post.id === updatedPost.id ? updatedPost : post
+        )
+      );
+    };
+    return () => {
+      delete window.updateFeedMainPost;
+    };
+  }, []);
+
   // Close dropdowns when clicking outside
   useEffect(() => {
     const handleClickOutside = () => {
@@ -315,6 +329,15 @@ export default function FeedMain({ navigateTo, isAdmin = false }) {
             <div className="feed-post-tags">
               {post.category && (
                 <span className="feed-post-tag">#{post.category}</span>
+              )}
+              {typeof post.editCount === 'number' && post.editCount > 0 && (
+                <span className="feed-post-tag" style={{ background: '#f3f3f3', color: '#666' }}>Edited {post.editCount} {post.editCount === 1 ? 'time' : 'times'}</span>
+              )}
+              {/* Resolved/Unresolved tag for relevant categories */}
+              {['Marketplace', 'Roommate Request', 'Lost and Found'].includes(post.category) && (
+                <span className="feed-post-tag" style={{ background: post.resolved ? '#c6f6d5' : '#fed7d7', color: post.resolved ? '#276749' : '#c53030', marginLeft: '6px' }}>
+                  {post.resolved ? 'Resolved' : 'Unresolved'}
+                </span>
               )}
             </div>
 


### PR DESCRIPTION
### For User Story 113:
- As a user, I want to mark my posts as **resolved** so others know that my roommate request, marketplace listing, or lost & found post is no longer active.
